### PR TITLE
Feature/567 Upgrade To Postgres 13.4 and prepare for multiarch docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This list shows all available images and the content / use case description
 
 ### ehrbase-postgresql-db.dockerfile
 
-This image contains the full installation of POSTGRESQL version 13.3
+This image contains the full installation of POSTGRESQL version 13.4
 
 Extensions/plugins like temporary_tables and jsquery are not longer required.
 All functionallity that was provided by these plugins is in the past 
@@ -38,7 +38,7 @@ related scripts.
 
 #### Containing software
 
-* POSTGRESQL 13.3-apline
+* POSTGRESQL 13.4-apline
 
 
 
@@ -50,7 +50,7 @@ Pull docker image from docker hub and start with default parameters
 docker run --name ehrdb \
            -e POSTGRES_PASSWORD=postgres \
            -d -p 5432:5432 \
-           ehrbase/ehrbase-postgres:13.3
+           ehrbase/ehrbase-postgres:13.4
 ```
 
 
@@ -64,7 +64,7 @@ docker run --name ehrdb \
            -e EHRBASE_USER=myuser \
            -e EHRBASE_PASSWORD=mypassword \
            -d -p 5432:5432 \
-           ehrbase/ehrbase-postgres:13.3
+           ehrbase/ehrbase-postgres:13.4
 ```
 
 If you want to set specific parameters, provide environment variables with

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Docker images used by EHRbase
   - [Images](#images)
     - [ehrbase-postgresql-db.dockerfile](#ehrbase-postgresql-fulldockerfile)
       - [Containing software](#containing-software)
-      - [Installation](#installation)
+      - [Usage](#usage)
       - [Customization](#customization)
+      - [Build Your Own Image Locally](#build-your-own-image-locally)
 
 
 ## Images
@@ -88,7 +89,7 @@ The following parameters can be set via -e option:
 
 
 
-# Building Your Own Image Locally
+#### Build Your Own Image Locally
 
 ```bash
 cd dockerfiles
@@ -117,3 +118,6 @@ docker buildx build --push --platform=linux/amd64 \
     -t ehrbase/ehrbase-postgres:yourtag-001 \
     -f ehrbase-postgresql-db.dockerfile .
 ```
+
+NOTE: If you don't want to push the image to Docker Hub, use `--load` instead of `--push`.
+This will make the image available only for you locally.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ docker run --name ehrdb \
 # customized docker run command
 docker run --name ehrdb \
            -e POSTGRES_PASSWORD=mypostgres \
-           -e EHRBASE_USER=myuser
-           -e EHRBASE_PASSWORD=mypassword
+           -e EHRBASE_USER=myuser \
+           -e EHRBASE_PASSWORD=mypassword \
            -d -p 5432:5432 \
            ehrbase/ehrbase-postgres:13.3
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Docker images used by EHRbase
 
+
 ## Table of contents
 - [docker](#docker)
   - [Table of contents](#table-of-contents)
@@ -11,6 +12,7 @@ Docker images used by EHRbase
       - [Installation](#installation)
       - [Customization](#customization)
 
+
 ## Images
 
 This list shows all available images and the content / use case description
@@ -18,6 +20,8 @@ This list shows all available images and the content / use case description
 | Image file name         | Description                                          |
 | ----------------------- | ---------------------------------------------------- |
 | ehrbase-postgresql-db   | Cloud-ready PostgreSQL DB image (not for production! |
+
+
 
 ### ehrbase-postgresql-db.dockerfile
 
@@ -30,11 +34,15 @@ now is handled by scripts/db-setup.sql.
 For reference you can check the archive folder with old docker files and all 
 related scripts.
 
+
+
 #### Containing software
 
 * POSTGRESQL 13.3-apline
 
-#### Installation
+
+
+#### Usage
 
 Pull docker image from docker hub and start with default parameters
 
@@ -45,12 +53,24 @@ docker run --name ehrdb \
            ehrbase/ehrbase-postgres:13.3
 ```
 
+
+
 #### Customization
 
-If you want to set specific parameters use environment variables provided with
-the -e option to the docker run command. This will be used to set the specific
-parameters for root postgres user password and ehrbase user and password. If not
-provided the default values will be used.
+```bash
+# customized docker run command
+docker run --name ehrdb \
+           -e POSTGRES_PASSWORD=mypostgres \
+           -e EHRBASE_USER=myuser
+           -e EHRBASE_PASSWORD=mypassword
+           -d -p 5432:5432 \
+           ehrbase/ehrbase-postgres:13.3
+```
+
+If you want to set specific parameters, provide environment variables with
+the `-e` option to `docker run` command. Example above sets custom values
+for root postgres user password and ehrbase user and password. If not
+provided the default values from table below will apply.
 
 The following parameters can be set via -e option:
 
@@ -59,3 +79,30 @@ The following parameters can be set via -e option:
 | POSTGRES_PASSWORD | Password for postgres     | postgres |
 | EHRBASE_USER      | Username for ehrbase user | ehrbase  |
 | EHRBASE_PASSWORD  | Password for ehrbase user | ehrbase  |
+
+
+
+# Building Your Own Image Locally
+
+```bash
+cd dockerfiles
+
+# provides build runtimes for addition platforms
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+# creates a 'docker-container' driver
+# which allows building for multiple platforms 
+docker buildx create --use --name multiarchbuilder
+
+# shows build Driver and available target platforms
+docker buildx inspect multiarchbuilder
+
+# builds image for specific platforms
+# and pushes it to docker-hub
+docker buildx build --push --platform=linux/arm64,linux/amd64 \
+    -t ehrbase/ehrbase-postgres:youtag-001 \
+    -f ehrbase-postgresql-db.dockerfile .
+
+```
+
+NOTE: If you want to build for one platform only, just provide only the one you need i.e. `--platform=linux/amd64`

--- a/README.md
+++ b/README.md
@@ -43,12 +43,17 @@ related scripts.
 
 
 #### Usage
+NOTE: there is possibly an issue with Moby's BuildKit (`docker buildx`) which requires to set a custom PGDATA folder to run the container successfully.
+See https://github.com/docker-library/postgres/issues/881#issuecomment-918414825 for more details.
+
+
 
 Pull docker image from docker hub and start with default parameters
 
 ```bash
 docker run --name ehrdb \
            -e POSTGRES_PASSWORD=postgres \
+           -e PGDATA=/tmp \
            -d -p 5432:5432 \
            ehrbase/ehrbase-postgres:13.4
 ```
@@ -63,6 +68,7 @@ docker run --name ehrdb \
            -e POSTGRES_PASSWORD=mypostgres \
            -e EHRBASE_USER=myuser \
            -e EHRBASE_PASSWORD=mypassword \
+           -e PGDATA=/tmp \
            -d -p 5432:5432 \
            ehrbase/ehrbase-postgres:13.4
 ```

--- a/README.md
+++ b/README.md
@@ -100,9 +100,14 @@ docker buildx inspect multiarchbuilder
 # builds image for specific platforms
 # and pushes it to docker-hub
 docker buildx build --push --platform=linux/arm64,linux/amd64 \
-    -t ehrbase/ehrbase-postgres:youtag-001 \
+    -t ehrbase/ehrbase-postgres:yourtag-001 \
     -f ehrbase-postgresql-db.dockerfile .
 
 ```
 
-NOTE: If you want to build for one platform only, just provide only the one you need i.e. `--platform=linux/amd64`
+NOTE: If you want to build for one platform only, just provide only the one you need i.e.
+```
+docker buildx build --push --platform=linux/amd64 \
+    -t ehrbase/ehrbase-postgres:yourtag-001 \
+    -f ehrbase-postgresql-db.dockerfile .
+```

--- a/dockerfiles/ehrbase-postgresql-db.dockerfile
+++ b/dockerfiles/ehrbase-postgresql-db.dockerfile
@@ -18,9 +18,3 @@ ENV EHRBASE_PASSWORD=${EHRBASE_PASSWORD}
 # NOTE: check postgres's docker docs for details
 #       https://hub.docker.com/_/postgres/
 COPY scripts/db-setup.sql /docker-entrypoint-initdb.d/
-
-# ALLOW CONNECTIONS FROM ALL ADRESSES & LISTEN TO ALL INTERFACES
-# NOTE: locally works w/o this additional settings
-RUN echo "host  all  all   0.0.0.0/0  scram-sha-256" >> ${PGDATA}/pg_hba.conf; \
-    echo "listen_addresses='*'" >> ${PGDATA}/postgresql.conf; \
-    ls -la ${PGDATA}

--- a/dockerfiles/ehrbase-postgresql-db.dockerfile
+++ b/dockerfiles/ehrbase-postgresql-db.dockerfile
@@ -1,3 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM --platform=$BUILDPLATFORM postgres:13.3-alpine
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "Running on $BUILDPLATFORM, building EHRbase PostgreSQL DB for $TARGETPLATFORM" > /log
+
 FROM postgres:13.3-alpine
 
 # SHOW POSTGRES SERVER AND CLIENT VERSION

--- a/dockerfiles/ehrbase-postgresql-db.dockerfile
+++ b/dockerfiles/ehrbase-postgresql-db.dockerfile
@@ -1,10 +1,8 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM postgres:13.3-alpine
+FROM --platform=$BUILDPLATFORM postgres:13.4-alpine
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "Running on $BUILDPLATFORM, building EHRbase PostgreSQL DB for $TARGETPLATFORM" > /log
-
-FROM postgres:13.3-alpine
 
 # SHOW POSTGRES SERVER AND CLIENT VERSION
 RUN postgres -V; \

--- a/dockerfiles/scripts/db-setup.sql
+++ b/dockerfiles/scripts/db-setup.sql
@@ -17,6 +17,9 @@ CREATE EXTENSION IF NOT EXISTS "ltree" SCHEMA ext;
 
 -- setup the search_patch so the extensions can be found
 ALTER DATABASE ehrbase SET search_path TO "$user",public,ext;
+-- ensure INTERVAL is ISO8601 encoded
+alter database ehrbase SET intervalstyle = 'iso_8601';
+
 GRANT ALL ON ALL FUNCTIONS IN SCHEMA ext TO :db_user;
 
 -- load the temporal_tables PLPG/SQL functions to emulate the coded extension


### PR DESCRIPTION
- uses postgres:13.4-alpine as base image
- prepared Dockerfile to allow builds with `docker buildx (Moby BuildKit)
- updated db-setup.sql script to contain 
  ```
  -- ensure INTERVAL is ISO8601 encoded
  alter database ehrbase SET intervalstyle = 'iso_8601';
  ```

NOTE: I've built and pushed the image `ehrbase/ehrbase-postgres:13.4` based on this branch so it's available from Docker Hub. Fall back to **ehrbase/ehrbase-postgres:13.3** if you run into any issues with this image.